### PR TITLE
Add export field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "types/index.d.ts",
+  "exports": {
+    "require": "./lib/index.cjs.js",
+    "import": "./lib/index.esm.js",
+    "types": "./types/index.d.ts"
+  },
   "files": [
     "lib",
     "types",


### PR DESCRIPTION
When the `export` field is missing vitest is using CommonJS version of the package even if the `module` key is specified which leads to problems with importing vitest from inside the package in a ESM project.

For example using:
```
chrome.runtime.connect('test');
```
leads to:
```
TypeError: Cannot read properties of undefined (reading 'fn')
 ❯ addFunction node_modules/vitest-chrome/src/add-elements.ts:73:12
 ❯ Object.get node_modules/vitest-chrome/src/createHandler.ts:64:20
```

See: [https://github.com/vitest-dev/vitest/discussions/4233](https://github.com/vitest-dev/vitest/discussions/4233)