### PR TITLE
chore: add a prepare step so that git dependencies build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vitest-chrome.d.ts"
   ],
   "scripts": {
+    "prepare": "run-s build",
     "build": "run-s build:clean build:pro build:types build:copy",
     "build:clean": "rm -rf lib types",
     "build:copy": "copyfiles -f src/vitest-chrome.d.ts types",


### PR DESCRIPTION
It is convenient to be able to specify dependencies in package.json which point to particular git commits.  One use case is allowing dependencies on PRs which are not yet merged and published to npm.org, such as

- https://github.com/probil/vitest-chrome/pull/1

in order to obtain functioning ESM support.

In theory this should be achievable via:

    "vitest-chrome": "probil/vitest-chrome#5fb1634b"

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies
states:

> When installing from a git repository, the presence of certain fields in the package.json will cause npm to believe it needs to perform a build. To do so your repository will be cloned into a temporary directory, all of its deps installed, relevant scripts run, and the resulting directory packed and installed.
>
> This flow will occur if your git dependency uses workspaces, or if any of the following scripts are present:
>
> - `build`
> - `prepare`
> - `prepack`
> - `preinstall`
> - `install`
> - `postinstall`

However it seems that, at least with pnpm, the presence of a `build` step is not sufficient.

So add a `prepare` step which just dispatches to the `build` step.  This makes vitest-chrome installable via a git dependency.

See also the backport: https://github.com/extend-chrome/jest-chrome/pull/37